### PR TITLE
Integrate GTest Framework

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -6,7 +6,7 @@ AUTOMAKE_OPTIONS = foreign
 # Extra clean files so that maintainer-clean removes *everything*
 DISTCLEANFILES = \
 	aclocal.m4 autom4te.cache compile config.guess config.sub \
-	configure config.h.in config.h.in~ depcomp install-sh ltmain.sh     \
+	configure config.h.in config.h.in~ depcomp install-sh ltmain.sh \
 	Makefile.in missing
 
 SUBDIRS = codecparsers common vaapi decoder encoder vpp pkgconfig

--- a/Makefile.am
+++ b/Makefile.am
@@ -11,7 +11,7 @@ DISTCLEANFILES = \
 
 SUBDIRS = codecparsers common vaapi decoder encoder vpp pkgconfig
 if ENABLE_DOCS
-	SUBDIRS += doc
+SUBDIRS += doc
 endif
 
 if ENABLE_V4L2

--- a/Makefile.am
+++ b/Makefile.am
@@ -9,7 +9,7 @@ DISTCLEANFILES = \
 	configure config.h.in config.h.in~ depcomp install-sh ltmain.sh \
 	Makefile.in missing
 
-SUBDIRS = codecparsers common vaapi decoder encoder vpp pkgconfig
+SUBDIRS = common codecparsers vaapi decoder encoder vpp pkgconfig
 if ENABLE_DOCS
 SUBDIRS += doc
 endif

--- a/capi/Makefile.am
+++ b/capi/Makefile.am
@@ -1,38 +1,37 @@
 INCLUDES = -I$(top_srcdir) \
-           -I$(top_srcdir)/interface \
-		   $(NULL)
+	-I$(top_srcdir)/interface \
+	$(NULL)
 
 libyami_capi_source_c = \
-        VideoDecoderCapi.cpp \
-        VideoEncoderCapi.cpp \
-        $(NULL)
+	VideoDecoderCapi.cpp \
+	VideoEncoderCapi.cpp \
+	$(NULL)
 
 libyami_capi_source_h = \
-        VideoDecoderCapi.h \
-        VideoEncoderCapi.h \
-        $(NULL)
+	VideoDecoderCapi.h \
+	VideoEncoderCapi.h \
+	$(NULL)
 
 libyami_capi_source_h_priv = \
-        $(NULL)
+	$(NULL)
 
 libyami_capi_la_LIBADD = \
-		$(top_builddir)/decoder/libyami_decoder.la \
-		$(top_builddir)/encoder/libyami_encoder.la \
-		$(NULL)
+	$(top_builddir)/decoder/libyami_decoder.la \
+	$(top_builddir)/encoder/libyami_encoder.la \
+	$(NULL)
 
 libyami_capi_ldflags = \
-        $(LIBYAMI_LT_LDFLAGS) \
-        $(NULL)
+	$(LIBYAMI_LT_LDFLAGS) \
+	$(NULL)
 
 libyami_capi_cppflags = \
-        $(LIBVA_CFLAGS) \
-        $(NULL)
+	$(LIBVA_CFLAGS) \
+	$(NULL)
 
-
-lib_LTLIBRARIES	               = libyami_capi.la
+lib_LTLIBRARIES             = libyami_capi.la
 libyami_capiincludedir      = $(includedir)/libyami_capi
 libyami_capiinclude_HEADERS = $(libyami_capi_source_h)
-noinst_HEADERS                 = $(libyami_capi_source_h_priv)
+noinst_HEADERS              = $(libyami_capi_source_h_priv)
 libyami_capi_la_SOURCES     = $(libyami_capi_source_c)
 libyami_capi_la_LDFLAGS     = $(libyami_capi_ldflags)
 libyami_capi_la_CPPFLAGS    = $(libyami_capi_cppflags)

--- a/capi/Makefile.am
+++ b/capi/Makefile.am
@@ -36,6 +36,34 @@ libyami_capi_la_SOURCES     = $(libyami_capi_source_c)
 libyami_capi_la_LDFLAGS     = $(libyami_capi_ldflags)
 libyami_capi_la_CPPFLAGS    = $(libyami_capi_cppflags)
 
+if ENABLE_UNITTESTS
+noinst_PROGRAMS = unittest
+
+unittest_SOURCES = \
+	$(top_builddir)/common/unittest_main.cpp \
+	$(NULL)
+
+unittest_LDFLAGS = \
+	$(GTEST_LDFLAGS) \
+	$(NULL)
+
+unittest_LDADD = \
+	libyami_capi.la \
+	$(GTEST_LIBS) \
+	$(NULL)
+
+unittest_CPPFLAGS = \
+	$(GTEST_CPPFLAGS) \
+	$(NULL)
+
+unittest_CXXFLAGS = \
+	$(GTEST_CXXFLAGS) \
+	$(NULL)
+
+check-local: unittest
+	$(builddir)/unittest
+endif
+
 DISTCLEANFILES = \
 	Makefile.in
 

--- a/codecparsers/Makefile.am
+++ b/codecparsers/Makefile.am
@@ -57,6 +57,10 @@ libyami_codecparser_cppflags = \
 	-Dvp8dx_bool_decoder_fill=libyami_vp8dx_bool_decoder_fill \
 	$(NULL)
 
+libyami_codecparser_la_LIBADD = \
+	$(top_builddir)/common/libyami_common.la \
+	$(NULL)
+
 lib_LTLIBRARIES                    = libyami_codecparser.la
 libyami_codecparserincludedir      = ${includedir}/libyami_codecparser
 libyami_codecparserinclude_HEADERS = $(libyami_codecparser_source_h)

--- a/codecparsers/Makefile.am
+++ b/codecparsers/Makefile.am
@@ -69,6 +69,34 @@ libyami_codecparser_la_SOURCES     = $(libyami_codecparser_source_c)
 libyami_codecparser_la_LDFLAGS     = $(libyami_codecparser_ldflags)
 libyami_codecparser_la_CPPFLAGS    = $(libyami_codecparser_cppflags)
 
+if ENABLE_UNITTESTS
+noinst_PROGRAMS = unittest
+
+unittest_SOURCES = \
+	$(top_builddir)/common/unittest_main.cpp \
+	$(NULL)
+
+unittest_LDFLAGS = \
+	$(GTEST_LDFLAGS) \
+	$(NULL)
+
+unittest_LDADD = \
+	libyami_codecparser.la \
+	$(GTEST_LIBS) \
+	$(NULL)
+
+unittest_CPPFLAGS = \
+	$(GTEST_CPPFLAGS) \
+	$(NULL)
+
+unittest_CXXFLAGS = \
+	$(GTEST_CXXFLAGS) \
+	$(NULL)
+
+check-local: unittest
+	$(builddir)/unittest
+endif
+
 DISTCLEANFILES = \
 	Makefile.in
 

--- a/codecparsers/Makefile.am
+++ b/codecparsers/Makefile.am
@@ -1,69 +1,69 @@
 INCLUDES = -I$(top_srcdir)
 
 libyami_codecparser_source_c = \
-        bitreader.c \
-        bytereader.c \
-        bytewriter.c \
-        h264parser.c \
-        h265parser.c \
-        mpegvideoparser.c \
-        mpeg4parser.c \
-        vc1parser.c \
-        vp8utils.c \
-        vp8rangedecoder.c \
-        vp8parser.c \
-        vp9quant.c \
-        vp9parser.c\
-        dboolhuff.c \
-        jpegparser.c \
-        parserutils.c \
-        nalutils.c \
-        bitwriter.c \
+	bitreader.c \
+	bytereader.c \
+	bytewriter.c \
+	h264parser.c \
+	h265parser.c \
+	mpegvideoparser.c \
+	mpeg4parser.c \
+	vc1parser.c \
+	vp8utils.c \
+	vp8rangedecoder.c \
+	vp8parser.c \
+	vp9quant.c \
+	vp9parser.c\
+	dboolhuff.c \
+	jpegparser.c \
+	parserutils.c \
+	nalutils.c \
+	bitwriter.c \
 	$(NULL)
 
 libyami_codecparser_source_h_priv = \
-        bitreader.h \
-        bytereader.h \
-        bytewriter.h \
-        h264parser.h \
-        h265parser.h \
-        mpegvideoparser.h \
-        mpeg4parser.h \
-        vc1parser.h \
-        vp8utils.h \
-        vp8rangedecoder.h \
-        vp8parser.h \
-        vp9quant.h \
-        vp9parser.h \
-        jpegparser.h \
-        parserutils.h \
-        nalutils.h \
-        bitwriter.h \
+	bitreader.h \
+	bytereader.h \
+	bytewriter.h \
+	h264parser.h \
+	h265parser.h \
+	mpegvideoparser.h \
+	mpeg4parser.h \
+	vc1parser.h \
+	vp8utils.h \
+	vp8rangedecoder.h \
+	vp8parser.h \
+	vp9quant.h \
+	vp9parser.h \
+	jpegparser.h \
+	parserutils.h \
+	nalutils.h \
+	bitwriter.h \
 	$(NULL)
 
 libyami_codecparser_source_h_priv = \
-		dboolhuff.h \
+	dboolhuff.h \
 	$(NULL)
 
 EXTRA_DIST = dboolhuff.LICENSE dboolhuff.PATENTS dboolhuff.AUTHORS
 
 libyami_codecparser_ldflags = \
-    $(LIBYAMI_LT_LDFLAGS) \
+	$(LIBYAMI_LT_LDFLAGS) \
 	$(NULL)
 
 libyami_codecparser_cppflags = \
-   -Dvp8_norm=libyami_vp8_norm \
-   -Dvp8dx_start_decode=libyami_vp8dx_start_decode \
-   -Dvp8dx_bool_decoder_fill=libyami_vp8dx_bool_decoder_fill
+	-Dvp8_norm=libyami_vp8_norm \
+	-Dvp8dx_start_decode=libyami_vp8dx_start_decode \
+	-Dvp8dx_bool_decoder_fill=libyami_vp8dx_bool_decoder_fill \
 	$(NULL)
 
-lib_LTLIBRARIES			= libyami_codecparser.la
-libyami_codecparserincludedir         = ${includedir}/libyami_codecparser
-libyami_codecparserinclude_HEADERS   = $(libyami_codecparser_source_h)
-noinst_HEADERS                  = $(libyami_codecparser_source_h_priv)
-libyami_codecparser_la_SOURCES	= $(libyami_codecparser_source_c)
-libyami_codecparser_la_LDFLAGS	= $(libyami_codecparser_ldflags)
-libyami_codecparser_la_CPPFLAGS      = $(libyami_codecparser_cppflags)
+lib_LTLIBRARIES                    = libyami_codecparser.la
+libyami_codecparserincludedir      = ${includedir}/libyami_codecparser
+libyami_codecparserinclude_HEADERS = $(libyami_codecparser_source_h)
+noinst_HEADERS                     = $(libyami_codecparser_source_h_priv)
+libyami_codecparser_la_SOURCES     = $(libyami_codecparser_source_c)
+libyami_codecparser_la_LDFLAGS     = $(libyami_codecparser_ldflags)
+libyami_codecparser_la_CPPFLAGS    = $(libyami_codecparser_cppflags)
 
 DISTCLEANFILES = \
 	Makefile.in

--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -1,29 +1,29 @@
 INCLUDES = -I$(top_srcdir)
 
 libyami_common_source_c = \
-        log.cpp \
-        utils.cpp \
-        nalreader.cpp \
-        $(NULL)
+	log.cpp \
+	utils.cpp \
+	nalreader.cpp \
+	$(NULL)
 
 libyami_common_source_h_priv = \
-        log.h \
-        utils.h \
-        common_def.h \
-        nalreader.h \
+	log.h \
+	utils.h \
+	common_def.h \
+	nalreader.h \
 	$(NULL)
 
 libyami_common_ldflags = \
-        $(LIBYAMI_LT_LDFLAGS) \
-        $(LIBVA_LIBS) \
-        $(LIBVA_DRM_LIBS) \
+	$(LIBYAMI_LT_LDFLAGS) \
+	$(LIBVA_LIBS) \
+	$(LIBVA_DRM_LIBS) \
 	$(NULL)
 
 libyami_common_cppflags = \
-        $(LIBVA_CFLAGS) \
+	$(LIBVA_CFLAGS) \
 	$(NULL)
 
-lib_LTLIBRARIES	              = libyami_common.la
+lib_LTLIBRARIES               = libyami_common.la
 libyami_commonincludedir      = ${includedir}/libyami_common
 libyami_commoninclude_HEADERS = $(libyami_common_source_h)
 libyami_common_la_SOURCES     = $(libyami_common_source_c)

--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -30,6 +30,34 @@ libyami_common_la_SOURCES     = $(libyami_common_source_c)
 libyami_common_la_LDFLAGS     = $(libyami_common_ldflags)
 libyami_common_la_CPPFLAGS    = $(libyami_common_cppflags)
 
+if ENABLE_UNITTESTS
+noinst_PROGRAMS = unittest
+
+unittest_SOURCES = \
+	$(top_builddir)/common/unittest_main.cpp \
+	$(NULL)
+
+unittest_LDFLAGS = \
+	$(GTEST_LDFLAGS) \
+	$(NULL)
+
+unittest_LDADD = \
+	libyami_common.la \
+	$(GTEST_LIBS) \
+	$(NULL)
+
+unittest_CPPFLAGS = \
+	$(GTEST_CPPFLAGS) \
+	$(NULL)
+
+unittest_CXXFLAGS = \
+	$(GTEST_CXXFLAGS) \
+	$(NULL)
+
+check-local: unittest
+	$(builddir)/unittest
+endif
+
 DISTCLEANFILES = \
 	Makefile.in 
 

--- a/common/unittest_main.cpp
+++ b/common/unittest_main.cpp
@@ -1,0 +1,6 @@
+#include <gtest/gtest.h>
+
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/configure.ac
+++ b/configure.ac
@@ -74,6 +74,12 @@ fi
 AM_CONDITIONAL(ENABLE_TESTS_GLES,
     [test "x$enable_tests_gles" = "xyes"])
 
+HAVE_GTEST="no"
+ifdef([GTEST_LIB_CHECK],
+    [GTEST_LIB_CHECK([1.7.0], [:], [:])])
+AM_CONDITIONAL([ENABLE_UNITTESTS],
+    [test "x$HAVE_GTEST" = "xyes"])
+
 AC_ARG_ENABLE(dmabuf,
     [AC_HELP_STRING([--enable-dmabuf],
         [support dma_buf buffer sharing @<:@default=no@:>@])],

--- a/decoder/Makefile.am
+++ b/decoder/Makefile.am
@@ -108,6 +108,34 @@ libyami_decoder_la_SOURCES     = $(libyami_decoder_source_c)
 libyami_decoder_la_LDFLAGS     = $(libyami_decoder_ldflags)
 libyami_decoder_la_CPPFLAGS    = $(libyami_decoder_cppflags)
 
+if ENABLE_UNITTESTS
+noinst_PROGRAMS = unittest
+
+unittest_SOURCES = \
+	$(top_builddir)/common/unittest_main.cpp \
+	$(NULL)
+
+unittest_LDFLAGS = \
+	$(GTEST_LDFLAGS) \
+	$(NULL)
+
+unittest_LDADD = \
+	libyami_decoder.la \
+	$(GTEST_LIBS) \
+	$(NULL)
+
+unittest_CPPFLAGS = \
+	$(GTEST_CPPFLAGS) \
+	$(NULL)
+
+unittest_CXXFLAGS = \
+	$(GTEST_CXXFLAGS) \
+	$(NULL)
+
+check-local: unittest
+	$(builddir)/unittest
+endif
+
 DISTCLEANFILES = \
 	Makefile.in 
 

--- a/decoder/Makefile.am
+++ b/decoder/Makefile.am
@@ -1,104 +1,106 @@
 INCLUDES = -I$(top_srcdir) \
-           -I$(top_srcdir)/interface \
-           -I$(top_srcdir)/common \
-           -I$(top_srcdir)/vaapi \
-           -I$(top_srcdir)/codecparsers 
+	-I$(top_srcdir)/interface \
+	-I$(top_srcdir)/common \
+	-I$(top_srcdir)/vaapi \
+	-I$(top_srcdir)/codecparsers \
+	$(NULL)
 
 libyami_decoder_source_c = \
-        vaapidecoder_base.cpp \
-        vaapidecoder_host.cpp \
-        vaapidecsurfacepool.cpp \
-        vaapidecpicture.cpp \
+	vaapidecoder_base.cpp \
+	vaapidecoder_host.cpp \
+	vaapidecsurfacepool.cpp \
+	vaapidecpicture.cpp \
 	$(NULL)
 
 if BUILD_H264_DECODER
-        libyami_decoder_source_c += vaapidecoder_h264.cpp
-        libyami_decoder_source_c += vaapidecoder_h264_dpb.cpp
+libyami_decoder_source_c += vaapidecoder_h264.cpp
+libyami_decoder_source_c += vaapidecoder_h264_dpb.cpp
 endif
 
 if BUILD_H265_DECODER
-        libyami_decoder_source_c += vaapidecoder_h265.cpp
+libyami_decoder_source_c += vaapidecoder_h265.cpp
 endif
 
 if BUILD_VP8_DECODER
-        libyami_decoder_source_c += vaapidecoder_vp8.cpp
+libyami_decoder_source_c += vaapidecoder_vp8.cpp
 endif
 
 if BUILD_VP9_DECODER
-        libyami_decoder_source_c += vaapidecoder_vp9.cpp
+libyami_decoder_source_c += vaapidecoder_vp9.cpp
 endif
 
 if BUILD_JPEG_DECODER
-        libyami_decoder_source_c += vaapidecoder_jpeg.cpp
+libyami_decoder_source_c += vaapidecoder_jpeg.cpp
 endif
 
 if BUILD_FAKE_DECODER
-        libyami_decoder_source_c += vaapidecoder_fake.cpp
+libyami_decoder_source_c += vaapidecoder_fake.cpp
 endif
 
 libyami_decoder_source_h = \
-        ../interface/VideoCommonDefs.h      \
-        ../interface/VideoDecoderDefs.h      \
-        ../interface/VideoDecoderInterface.h \
-        ../interface/VideoDecoderHost.h \
+	../interface/VideoCommonDefs.h \
+	../interface/VideoDecoderDefs.h \
+	../interface/VideoDecoderInterface.h \
+	../interface/VideoDecoderHost.h \
 	$(NULL)
 
 libyami_decoder_source_h_priv = \
-        vaapidecoder_base.h \
-        vaapidecsurfacepool.h \
-        vaapidecpicture.h \
+	vaapidecoder_base.h \
+	vaapidecsurfacepool.h \
+	vaapidecpicture.h \
 	$(NULL)
 
 if BUILD_H264_DECODER
-        libyami_decoder_source_h_priv += vaapidecoder_h264.h
+libyami_decoder_source_h_priv += vaapidecoder_h264.h
 endif
 
 if BUILD_H265_DECODER
-        libyami_decoder_source_h_priv += vaapidecoder_h265.h
+libyami_decoder_source_h_priv += vaapidecoder_h265.h
 endif
 
 if BUILD_VP8_DECODER
-        libyami_decoder_source_h_priv += vaapidecoder_vp8.h
+libyami_decoder_source_h_priv += vaapidecoder_vp8.h
 endif
 
 if BUILD_VP9_DECODER
-        libyami_decoder_source_h_priv += vaapidecoder_vp9.h
+libyami_decoder_source_h_priv += vaapidecoder_vp9.h
 endif
 
 if BUILD_JPEG_DECODER
-        libyami_decoder_source_h_priv += vaapidecoder_jpeg.h
+libyami_decoder_source_h_priv += vaapidecoder_jpeg.h
 endif
 
 if BUILD_FAKE_DECODER
-        libyami_decoder_source_h_priv += vaapidecoder_fake.h
+libyami_decoder_source_h_priv += vaapidecoder_fake.h
 endif
 
 libyami_decoder_la_LIBADD = \
-		$(top_builddir)/common/libyami_common.la \
-		$(top_builddir)/vaapi/libyami_vaapi.la \
-		$(top_builddir)/codecparsers/libyami_codecparser.la
+	$(top_builddir)/common/libyami_common.la \
+	$(top_builddir)/vaapi/libyami_vaapi.la \
+	$(top_builddir)/codecparsers/libyami_codecparser.la \
+	$(NULL)
 
 libyami_decoder_ldflags = \
-        $(LIBYAMI_LT_LDFLAGS) \
-        $(LIBVA_LIBS) \
-        $(LIBVA_DRM_LIBS) \
-        -ldl                 \
-        $(NULL)
+	$(LIBYAMI_LT_LDFLAGS) \
+	$(LIBVA_LIBS) \
+	$(LIBVA_DRM_LIBS) \
+	-ldl \
+	$(NULL)
 
 if ENABLE_X11
 libyami_decoder_ldflags += $(LIBVA_X11_LIBS) $(X11_LIBS)
 endif
 
 libyami_decoder_cppflags = \
-        $(LIBVA_CFLAGS) \
-        $(LIBVA_DRM_CFLAGS) \
+	$(LIBVA_CFLAGS) \
+	$(LIBVA_DRM_CFLAGS) \
 	$(NULL)
+
 if ENABLE_X11
 libyami_decoder_cppflags += $(LIBVA_X11_CFLAGS)
 endif
 
-
-lib_LTLIBRARIES	               = libyami_decoder.la
+lib_LTLIBRARIES                = libyami_decoder.la
 libyami_decoderincludedir      = $(includedir)/libyami_decoder
 libyami_decoderinclude_HEADERS = $(libyami_decoder_source_h)
 noinst_HEADERS                 = $(libyami_decoder_source_h_priv)

--- a/decoder/vaapidecoder_h264_dpb.cpp
+++ b/decoder/vaapidecoder_h264_dpb.cpp
@@ -407,7 +407,9 @@ bool VaapiDPBManager::addDPB(const VaapiFrameStore::Ptr& newFrameStore,
             if (!foundPicture) {
                 bool ret = true;
                 if (newFrameStore->hasFrame()) {
-                    newFrameStore->m_outputNeeded++;
+                    if (newFrameStore->m_outputNeeded == 0) {
+                        newFrameStore->m_outputNeeded++;
+                    }
                     ret = outputDPB(newFrameStore, pic);
                 } else {
                     m_prevFrameStore = newFrameStore;   // wait for a complete frame to render

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -2,34 +2,35 @@ all: html
 install-data-local: install-html
 
 EXTRA_DIST = \
-    doc.config          \
-    $(NULL)
+	doc.config \
+	$(NULL)
 
 LIBYAMI_DOC_STRIP_DIR = $(top_srcdir)/common $(top_srcdir)/vaapi $(top_srcdir)/decoder $(top_srcdir)/encoder $(top_srcdir)/interface
-LIBYAMI_DOC_STRIP_FILES = vaapibuffer.h             \
-    $(top_srcdir)/vaapi/vaapiimage.h               \
-    $(top_srcdir)/vaapi/vaapiptrs.h                \
-    $(top_srcdir)/vaapi/vaapisurface.h             \
-    $(top_srcdir)/vaapi/vaapiutils.h               \
-    $(top_srcdir)/decoder/vaapidecoder_base.h       \
-    $(top_srcdir)/decoder/vaapidecoder_h264.h       \
-    $(top_srcdir)/decoder/vaapidecoder_jpeg.h       \
-    $(top_srcdir)/decoder/vaapidecoder_vp8.h        \
-    $(top_srcdir)/decoder/vaapidecsurfacepool.h        \
-    $(top_srcdir)/decoder/vaapipicture.h            \
-    $(top_srcdir)/decoder/vaapisurfacebuf_pool.h    \
-    $(top_srcdir)/encoder/vaapicodedbuffer.h        \
-    $(top_srcdir)/encoder/vaapiencoder_base.h       \
-    $(top_srcdir)/encoder/vaapiencoder_h264.h       \
-    $(top_srcdir)/encoder/vaapiencpicture.h         \
-    $(top_srcdir)/interface/VideoDecoderDefs.h      \
-    $(top_srcdir)/interface/VideoDecoderHost.h      \
-    $(top_srcdir)/interface/VideoDecoderInterface.h \
-    $(top_srcdir)/interface/VideoEncoderAVC.h       \
-    $(top_srcdir)/interface/VideoEncoderBase.h      \
-    $(top_srcdir)/interface/VideoEncoderDefs.h       \
-    $(top_srcdir)/interface/VideoEncoderHost.h      \
-    $(top_srcdir)/interface/VideoEncoderInterface.h
+LIBYAMI_DOC_STRIP_FILES = vaapibuffer.h \
+	$(top_srcdir)/vaapi/vaapiimage.h \
+	$(top_srcdir)/vaapi/vaapiptrs.h \
+	$(top_srcdir)/vaapi/vaapisurface.h \
+	$(top_srcdir)/vaapi/vaapiutils.h \
+	$(top_srcdir)/decoder/vaapidecoder_base.h \
+	$(top_srcdir)/decoder/vaapidecoder_h264.h \
+	$(top_srcdir)/decoder/vaapidecoder_jpeg.h \
+	$(top_srcdir)/decoder/vaapidecoder_vp8.h \
+	$(top_srcdir)/decoder/vaapidecsurfacepool.h \
+	$(top_srcdir)/decoder/vaapipicture.h \
+	$(top_srcdir)/decoder/vaapisurfacebuf_pool.h \
+	$(top_srcdir)/encoder/vaapicodedbuffer.h \
+	$(top_srcdir)/encoder/vaapiencoder_base.h \
+	$(top_srcdir)/encoder/vaapiencoder_h264.h \
+	$(top_srcdir)/encoder/vaapiencpicture.h \
+	$(top_srcdir)/interface/VideoDecoderDefs.h \
+	$(top_srcdir)/interface/VideoDecoderHost.h \
+	$(top_srcdir)/interface/VideoDecoderInterface.h \
+	$(top_srcdir)/interface/VideoEncoderAVC.h \
+	$(top_srcdir)/interface/VideoEncoderBase.h \
+	$(top_srcdir)/interface/VideoEncoderDefs.h \
+	$(top_srcdir)/interface/VideoEncoderHost.h \
+	$(top_srcdir)/interface/VideoEncoderInterface.h \
+	$(NULL)
 
 export LIBYAMI_DOC_STRIP_DIR
 export LIBYAMI_DOC_STRIP_FILES
@@ -41,13 +42,13 @@ html: html/index.html
 install-html-local:
 	install -d $(DESTDIR)$(docdir)/html
 	for file in `ls html/` ; do \
-        if test -f html/$$file ; then \
-            install -m 0644 html/$$file $(DESTDIR)$(docdir)/html ; \
-        else \
-            install -d $(DESTDIR)$(docdir)/html/$$file ; \
-            install -m 0644 html/$$file/* $(DESTDIR)$(docdir)/html/$$file; \
-        fi ; \
-    done
+	if test -f html/$$file ; then \
+		install -m 0644 html/$$file $(DESTDIR)$(docdir)/html ; \
+	else \
+		install -d $(DESTDIR)$(docdir)/html/$$file ; \
+		install -m 0644 html/$$file/* $(DESTDIR)$(docdir)/html/$$file; \
+	fi ; \
+	done
 uninstall-local:
 	rm -rf $(DESTDIR)$(docdir)/html
 endif

--- a/encoder/Makefile.am
+++ b/encoder/Makefile.am
@@ -1,91 +1,94 @@
 INCLUDES = -I$(top_srcdir) \
-           -I$(top_srcdir)/interface \
-           -I$(top_srcdir)/common \
-           -I$(top_srcdir)/vaapi \
-           -I$(top_srcdir)/codecparsers
+	-I$(top_srcdir)/interface \
+	-I$(top_srcdir)/common \
+	-I$(top_srcdir)/vaapi \
+	-I$(top_srcdir)/codecparsers \
+	$(NULL)
 
 libyami_encoder_source_c = \
-        vaapicodedbuffer.cpp \
-        vaapiencpicture.cpp \
-        vaapiencoder_base.cpp \
-        vaapiencoder_host.cpp \
+	vaapicodedbuffer.cpp \
+	vaapiencpicture.cpp \
+	vaapiencoder_base.cpp \
+	vaapiencoder_host.cpp \
 	$(NULL)
 
 if BUILD_H264_ENCODER
-        libyami_encoder_source_c += vaapiencoder_h264.cpp
+libyami_encoder_source_c += vaapiencoder_h264.cpp
 endif
 
 if BUILD_JPEG_ENCODER
-        libyami_encoder_source_c += vaapiencoder_jpeg.cpp
+libyami_encoder_source_c += vaapiencoder_jpeg.cpp
 endif
 
 if BUILD_VP8_ENCODER
-        libyami_encoder_source_c += vaapiencoder_vp8.cpp
+libyami_encoder_source_c += vaapiencoder_vp8.cpp
 endif
 
 if BUILD_H265_ENCODER
-        libyami_encoder_source_c += vaapiencoder_hevc.cpp
+libyami_encoder_source_c += vaapiencoder_hevc.cpp
 endif
 
 libyami_encoder_source_h = \
-        ../interface/VideoCommonDefs.h      \
-        ../interface/VideoEncoderDefs.h      \
-        ../interface/VideoEncoderInterface.h \
-        ../interface/VideoEncoderHost.h \
+	../interface/VideoCommonDefs.h      \
+	../interface/VideoEncoderDefs.h      \
+	../interface/VideoEncoderInterface.h \
+	../interface/VideoEncoderHost.h \
 	$(NULL)
 
 libyami_encoder_source_h_priv = \
-        vaapicodedbuffer.h \
-        vaapiencpicture.h \
-        vaapiencoder_base.h \
+	vaapicodedbuffer.h \
+	vaapiencpicture.h \
+	vaapiencoder_base.h \
 	$(NULL)
 
 if BUILD_H264_ENCODER
-        libyami_encoder_source_h_priv += vaapiencoder_h264.h
+libyami_encoder_source_h_priv += vaapiencoder_h264.h
 endif
 
 if BUILD_JPEG_ENCODER
-        libyami_encoder_source_h_priv += vaapiencoder_jpeg.h 
+libyami_encoder_source_h_priv += vaapiencoder_jpeg.h 
 endif
 
 if BUILD_VP8_ENCODER
-        libyami_encoder_source_h_priv += vaapiencoder_vp8.h
+libyami_encoder_source_h_priv += vaapiencoder_vp8.h
 endif
 
 if BUILD_H265_ENCODER
-        libyami_encoder_source_h_priv += vaapiencoder_hevc.h
+libyami_encoder_source_h_priv += vaapiencoder_hevc.h
 endif
 
-
 libyami_encoder_la_LIBADD = \
-		$(top_builddir)/common/libyami_common.la \
-		$(top_builddir)/vaapi/libyami_vaapi.la \
-		$(top_builddir)/codecparsers/libyami_codecparser.la
+	$(top_builddir)/common/libyami_common.la \
+	$(top_builddir)/vaapi/libyami_vaapi.la \
+	$(top_builddir)/codecparsers/libyami_codecparser.la \
+	$(NULL)
 
 libyami_encoder_ldflags = \
-        $(LIBYAMI_LT_LDFLAGS) \
-        $(LIBVA_LIBS) \
-        $(LIBVA_DRM_LIBS) \
-        -ldl                 \
-        $(NULL)
+	$(LIBYAMI_LT_LDFLAGS) \
+	$(LIBVA_LIBS) \
+	$(LIBVA_DRM_LIBS) \
+	-ldl \
+	$(NULL)
+
 if ENABLE_X11
 libyami_encoder_ldflags += $(LIBVA_X11_LIBS) $(X11_LIBS)
 endif
 
 libyami_encoder_cppflags = \
-        $(LIBVA_CFLAGS) \
-        $(LIBVA_DRM_CFLAGS) \
+	$(LIBVA_CFLAGS) \
+	$(LIBVA_DRM_CFLAGS) \
 	$(NULL)
+
 if ENABLE_X11
 libyami_encoder_cppflags += $(LIBVA_X11_CFLAGS)
 endif
 
-lib_LTLIBRARIES			  = libyami_encoder.la
+lib_LTLIBRARIES                = libyami_encoder.la
 libyami_encoderincludedir      = $(includedir)/libyami_encoder
 libyami_encoderinclude_HEADERS = $(libyami_encoder_source_h)
-noinst_HEADERS                   = $(libyami_encoder_source_h_priv)
-libyami_encoder_la_SOURCES	  = $(libyami_encoder_source_c)
-libyami_encoder_la_LDFLAGS	  = $(libyami_encoder_ldflags)
+noinst_HEADERS                 = $(libyami_encoder_source_h_priv)
+libyami_encoder_la_SOURCES     = $(libyami_encoder_source_c)
+libyami_encoder_la_LDFLAGS     = $(libyami_encoder_ldflags)
 libyami_encoder_la_CPPFLAGS    = $(libyami_encoder_cppflags)
 
 DISTCLEANFILES = \

--- a/encoder/Makefile.am
+++ b/encoder/Makefile.am
@@ -91,5 +91,33 @@ libyami_encoder_la_SOURCES     = $(libyami_encoder_source_c)
 libyami_encoder_la_LDFLAGS     = $(libyami_encoder_ldflags)
 libyami_encoder_la_CPPFLAGS    = $(libyami_encoder_cppflags)
 
+if ENABLE_UNITTESTS
+noinst_PROGRAMS = unittest
+
+unittest_SOURCES = \
+	$(top_builddir)/common/unittest_main.cpp \
+	$(NULL)
+
+unittest_LDFLAGS = \
+	$(GTEST_LDFLAGS) \
+	$(NULL)
+
+unittest_LDADD = \
+	libyami_encoder.la \
+	$(GTEST_LIBS) \
+	$(NULL)
+
+unittest_CPPFLAGS = \
+	$(GTEST_CPPFLAGS) \
+	$(NULL)
+
+unittest_CXXFLAGS = \
+	$(GTEST_CXXFLAGS) \
+	$(NULL)
+
+check-local: unittest
+	$(builddir)/unittest
+endif
+
 DISTCLEANFILES = \
 	Makefile.in

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -1,6 +1,7 @@
 INCLUDES = -I$(top_srcdir) -I$(top_srcdir)/tests
 
 bin_PROGRAMS =
+
 if ENABLE_X11
 bin_PROGRAMS += simpleplayer
 endif
@@ -10,9 +11,9 @@ bin_PROGRAMS += grid
 endif
 
 AM_CFLAGS = \
-	-I$(top_srcdir)			\
-	-I$(top_srcdir)/interface	\
-	$(LIBVA_CFLAGS)             \
+	-I$(top_srcdir) \
+	-I$(top_srcdir)/interface \
+	$(LIBVA_CFLAGS) \
 	$(NULL)
 
 DECODE_INPUT_SOURCES = \
@@ -22,14 +23,14 @@ DECODE_INPUT_SOURCES = \
 if ENABLE_AVFORMAT
 DECODE_INPUT_SOURCES += $(top_builddir)/tests/decodeinputavformat.cpp
 AM_CFLAGS += -D__STDC_CONSTANT_MACROS \
-			 $(LIBAVFORMAT_CFLAGS)
+	$(LIBAVFORMAT_CFLAGS)
 endif
 
 VPP_INPUT_SOURCES = \
 	$(DECODE_INPUT_SOURCES) \
 	$(top_builddir)/tests/vppinputoutput.cpp \
 	$(top_builddir)/tests/vppinputdecode.cpp \
-        $(top_builddir)/tests/vppinputasync.cpp \
+	$(top_builddir)/tests/vppinputasync.cpp \
 	$(top_builddir)/tests/vppoutputencode.cpp \
 	$(top_builddir)/tests/encodeinput.cpp \
 	$(top_builddir)/tests/encodeInputDecoder.cpp \
@@ -37,24 +38,24 @@ VPP_INPUT_SOURCES = \
 	$(NULL)
 
 AM_CPPFLAGS = $(AM_CFLAGS)
-YAMI_COMMON_LIBS 	= \
-	$(top_builddir)/common/libyami_common.la	\
-	$(top_builddir)/vaapi/libyami_vaapi.la		\
+YAMI_COMMON_LIBS = \
+	$(top_builddir)/common/libyami_common.la \
+	$(top_builddir)/vaapi/libyami_vaapi.la \
 	$(NULL)
 
 if ENABLE_X11
 YAMI_COMMON_LIBS += $(LIBVA_X11_LIBS) -lX11
 endif
 
-YAMI_DECODE_LIBS 	= \
-	$(YAMI_COMMON_LIBS)                            	\
-	$(top_builddir)/decoder/libyami_decoder.la      \
+YAMI_DECODE_LIBS = \
+	$(YAMI_COMMON_LIBS) \
+	$(top_builddir)/decoder/libyami_decoder.la \
 	$(NULL)
 
 if BUILD_STATIC
-YAMI_DECODE_LDFLAGS =						\
-	-Wl,--whole-archive					\
-	-Wl,$(top_builddir)/decoder/.libs/libyami_decoder.a	\
+YAMI_DECODE_LDFLAGS = \
+	-Wl,--whole-archive \
+	-Wl,$(top_builddir)/decoder/.libs/libyami_decoder.a \
 	-Wl,--no-whole-archive
 endif
 
@@ -67,44 +68,45 @@ YAMI_DECODE_LIBS += $(LIBAVFORMAT_LIBS)
 endif
 
 YAMI_ENCODE_LIBS = \
-	$(YAMI_COMMON_LIBS)                             \
-	$(top_builddir)/encoder/libyami_encoder.la      \
-	$(YAMI_DECODE_LIBS)								\
+	$(YAMI_COMMON_LIBS) \
+	$(top_builddir)/encoder/libyami_encoder.la \
+	$(YAMI_DECODE_LIBS) \
 	$(NULL)
 
 if BUILD_STATIC
-YAMI_ENCODE_LDFLAGS =						\
-	-Wl,--whole-archive					\
-	-Wl,$(top_builddir)/encoder/.libs/libyami_encoder.a	\
-	-Wl,--no-whole-archive					\
-	$(YAMI_DECODE_LDFLAGS)
+YAMI_ENCODE_LDFLAGS = \
+	-Wl,--whole-archive \
+	-Wl,$(top_builddir)/encoder/.libs/libyami_encoder.a \
+	-Wl,--no-whole-archive \
+	$(YAMI_DECODE_LDFLAGS) \
+	$(NULL)
 endif
 
 VPP_INPUT_LIBS = \
-    $(YAMI_COMMON_LIBS)   \
-    $(top_builddir)/vpp/libyami_vpp.la	\
-    $(LIBYAMI_LT_LDFLAGS) \
-    $(LIBVA_LIBS) \
-    $(LIBVA_DRM_LIBS) \
-    $(YAMI_ENCODE_LIBS) \
+	$(YAMI_COMMON_LIBS) \
+	$(top_builddir)/vpp/libyami_vpp.la \
+	$(LIBYAMI_LT_LDFLAGS) \
+	$(LIBVA_LIBS) \
+	$(LIBVA_DRM_LIBS) \
+	$(YAMI_ENCODE_LIBS) \
 	$(NULL)
 
 if BUILD_STATIC
-VPP_INPUT_LDFLAGS =					\
-	-Wl,--whole-archive				\
-	-Wl,$(top_builddir)/vpp/.libs/libyami_vpp.a	\
-	-Wl,--no-whole-archive				\
+VPP_INPUT_LDFLAGS = \
+	-Wl,--whole-archive \
+	-Wl,$(top_builddir)/vpp/.libs/libyami_vpp.a \
+	-Wl,--no-whole-archive \
 	$(YAMI_ENCODE_LDFLAGS)
 endif
 
 VPP_INPUT_CFLAGS = \
-    $(LIBVA_CFLAGS) \
+	$(LIBVA_CFLAGS) \
 	$(NULL)
 
 if ENABLE_X11
 simpleplayer_LDADD = $(YAMI_DECODE_LIBS)
 simpleplayer_LDFLAGS = $(YAMI_DECODE_LDFLAGS)
-simpleplayer_SOURCES	= simpleplayer.cpp $(DECODE_INPUT_SOURCES)
+simpleplayer_SOURCES = simpleplayer.cpp $(DECODE_INPUT_SOURCES)
 endif
 
 if ENABLE_DMABUF

--- a/pkgconfig/libyami_codecparser.pc.in
+++ b/pkgconfig/libyami_codecparser.pc.in
@@ -6,5 +6,6 @@ includedir=@includedir@
 Name: libyami_codecparser
 Description: Intel open source video streamer parsers
 Version: 1.0.0
+Requires: libyami_common
 Libs: -L${libdir} -lyami_codecparser
 Cflags: -I${includedir}/libyami_codecparser

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -10,9 +10,9 @@ endif
 endif
 
 AM_CFLAGS = \
-	-I$(top_srcdir)			\
-	-I$(top_srcdir)/interface	\
-	$(LIBVA_CFLAGS)             \
+	-I$(top_srcdir) \
+	-I$(top_srcdir)/interface \
+	$(LIBVA_CFLAGS) \
 	$(NULL)
 
 DECODE_INPUT_SOURCES = \
@@ -22,64 +22,67 @@ DECODE_INPUT_SOURCES = \
 if ENABLE_AVFORMAT
 DECODE_INPUT_SOURCES += decodeinputavformat.cpp
 AM_CFLAGS += -D__STDC_CONSTANT_MACROS \
-			 $(LIBAVFORMAT_CFLAGS)
+	$(LIBAVFORMAT_CFLAGS)
 endif
 
 AM_CPPFLAGS = $(AM_CFLAGS)
 
-YAMI_COMMON_LIBS 	= \
-	$(LIBVA_LIBS)								\
-	$(top_builddir)/common/libyami_common.la	\
-	$(top_builddir)/vaapi/libyami_vaapi.la		\
+YAMI_COMMON_LIBS = \
+	$(LIBVA_LIBS) \
+	$(top_builddir)/common/libyami_common.la \
+	$(top_builddir)/vaapi/libyami_vaapi.la \
 	$(NULL)
+
 if ENABLE_X11
 YAMI_COMMON_LIBS += $(LIBVA_X11_LIBS) -lX11
 endif
 
-YAMI_DECODE_LIBS 	= \
-	$(YAMI_COMMON_LIBS)                            	\
-	$(top_builddir)/decoder/libyami_decoder.la      \
+YAMI_DECODE_LIBS = \
+	$(YAMI_COMMON_LIBS) \
+	$(top_builddir)/decoder/libyami_decoder.la \
 	$(NULL)
 
 if BUILD_STATIC
-YAMI_DECODE_LDFLAGS =						\
-	-Wl,--whole-archive					\
-	-Wl,$(top_builddir)/decoder/.libs/libyami_decoder.a	\
+YAMI_DECODE_LDFLAGS = \
+	-Wl,--whole-archive \
+	-Wl,$(top_builddir)/decoder/.libs/libyami_decoder.a \
 	-Wl,--no-whole-archive
 endif
 
 if ENABLE_TESTS_GLES
 YAMI_DECODE_LIBS += $(LIBEGL_LIBS) $(LIBGLES2_LIBS)
 endif
+
 if ENABLE_AVFORMAT
 YAMI_DECODE_LIBS += $(LIBAVFORMAT_LIBS)
 endif
+
 if ENABLE_MD5
 YAMI_DECODE_LIBS += -lcrypto
 endif
 
 YAMI_ENCODE_LIBS = \
-	$(YAMI_COMMON_LIBS)                             \
-	$(top_builddir)/encoder/libyami_encoder.la      \
-	$(YAMI_DECODE_LIBS)								\
+	$(YAMI_COMMON_LIBS) \
+	$(top_builddir)/encoder/libyami_encoder.la \
+	$(YAMI_DECODE_LIBS) \
 	$(NULL)
 
 if BUILD_STATIC
-YAMI_ENCODE_LDFLAGS =						\
-	-Wl,--whole-archive					\
-	-Wl,$(top_builddir)/encoder/.libs/libyami_encoder.a	\
+YAMI_ENCODE_LDFLAGS = \
+	-Wl,--whole-archive \
+	-Wl,$(top_builddir)/encoder/.libs/libyami_encoder.a \
 	-Wl,--no-whole-archive
 endif
 
 V4L2_DECODE_LIBS = \
-	$(YAMI_DECODE_LIBS)                         \
-	$(top_builddir)/v4l2/libyami_v4l2.la        \
+	$(YAMI_DECODE_LIBS) \
+	$(top_builddir)/v4l2/libyami_v4l2.la \
 	$(NULL)
 
 if BUILD_STATIC
-V4L2_DECODE_LDFLAGS =						\
-	-Wl,--whole-archive					\
-	-Wl,$(top_builddir)/decoder/.libs/libyami_decoder.a	\
+V4L2_DECODE_LDFLAGS = \
+	-Wl,--whole-archive \
+	-Wl,$(top_builddir)/decoder/.libs/libyami_decoder.a \
 	-Wl,--no-whole-archive
 endif
 
@@ -90,60 +93,60 @@ V4L2_DECODE_LIBS += $(LIBEGL_LIBS) $(LIBGLES2_LIBS)
 endif
 
 V4L2_ENCODE_LIBS = \
-	$(YAMI_ENCODE_LIBS)                         \
-	$(top_builddir)/v4l2/libyami_v4l2.la        \
+	$(YAMI_ENCODE_LIBS) \
+	$(top_builddir)/v4l2/libyami_v4l2.la \
 	$(NULL)
 
 if BUILD_STATIC
-V4L2_ENCODE_LDFLAGS =						\
-	-Wl,--whole-archive					\
-	-Wl,$(top_builddir)/encoder/.libs/libyami_encoder.a	\
+V4L2_ENCODE_LDFLAGS = \
+	-Wl,--whole-archive \
+	-Wl,$(top_builddir)/encoder/.libs/libyami_encoder.a \
 	-Wl,--no-whole-archive
 endif
 
 CAPI_DECODE_LIBS = \
-	$(YAMI_DECODE_LIBS)							\
-	$(top_builddir)/capi/libyami_capi.la		\
+	$(YAMI_DECODE_LIBS) \
+	$(top_builddir)/capi/libyami_capi.la \
 	$(NULL)
 
 CAPI_ENCODE_LIBS = \
-	$(YAMI_ENCODE_LIBS)							\
-	$(top_builddir)/capi/libyami_capi.la		\
+	$(YAMI_ENCODE_LIBS) \
+	$(top_builddir)/capi/libyami_capi.la \
 	$(NULL)
 
 YAMI_VPP_LIBS = \
-    $(YAMI_COMMON_LIBS)   \
-    $(top_builddir)/vpp/libyami_vpp.la	\
-    $(LIBYAMI_LT_LDFLAGS) \
-    $(LIBVA_LIBS) \
-    $(LIBVA_DRM_LIBS) \
-    $(YAMI_ENCODE_LIBS) \
+	$(YAMI_COMMON_LIBS) \
+	$(top_builddir)/vpp/libyami_vpp.la \
+	$(LIBYAMI_LT_LDFLAGS) \
+	$(LIBVA_LIBS) \
+	$(LIBVA_DRM_LIBS) \
+	$(YAMI_ENCODE_LIBS) \
 	$(NULL)
 
 if BUILD_STATIC
-YAMI_VPP_LDFLAGS =					\
-	-Wl,--whole-archive				\
-	-Wl,$(top_builddir)/vpp/.libs/libyami_vpp.a	\
+YAMI_VPP_LDFLAGS = \
+	-Wl,--whole-archive \
+	-Wl,$(top_builddir)/vpp/.libs/libyami_vpp.a \
 	-Wl,--no-whole-archive
 endif
 
 YAMI_VPP_CFLAGS = \
-    $(LIBVA_CFLAGS) \
+	$(LIBVA_CFLAGS) \
 	$(NULL)
 
 if ENABLE_CAPI
-decodecapi_LDADD	= $(CAPI_DECODE_LIBS)
-decodecapi_SOURCES	= decodecapi.c decodehelp.h  decodeInputCapi.cpp decodeOutputCapi.cpp $(DECODE_INPUT_SOURCES) decodeoutput.cpp
+decodecapi_LDADD    = $(CAPI_DECODE_LIBS)
+decodecapi_SOURCES  = decodecapi.c decodehelp.h  decodeInputCapi.cpp decodeOutputCapi.cpp $(DECODE_INPUT_SOURCES) decodeoutput.cpp
 if ENABLE_TESTS_GLES
 decodecapi_SOURCES += ../egl/egl_util.c ./egl/gles2_help.c
 endif
 
-encodecapi_LDADD	= $(CAPI_ENCODE_LIBS)
-encodecapi_SOURCES	= encodecapi.c encodehelp.h encodeinput.cpp encodeInputCamera.cpp encodeInputDecoder.cpp encodeInputCapi.cpp $(DECODE_INPUT_SOURCES)
+encodecapi_LDADD    = $(CAPI_ENCODE_LIBS)
+encodecapi_SOURCES  = encodecapi.c encodehelp.h encodeinput.cpp encodeInputCamera.cpp encodeInputDecoder.cpp encodeInputCapi.cpp $(DECODE_INPUT_SOURCES)
 else
-yamidecode_LDADD	= $(YAMI_DECODE_LIBS)
-yamidecode_LDFLAGS	= $(YAMI_DECODE_LDFLAGS)
-yamidecode_SOURCES	= decode.cpp decodehelp.h $(DECODE_INPUT_SOURCES) decodeoutput.cpp
+yamidecode_LDADD    = $(YAMI_DECODE_LIBS)
+yamidecode_LDFLAGS  = $(YAMI_DECODE_LDFLAGS)
+yamidecode_SOURCES  = decode.cpp decodehelp.h $(DECODE_INPUT_SOURCES) decodeoutput.cpp
 if ENABLE_TESTS_GLES
 yamidecode_SOURCES += ../egl/egl_util.c ./egl/gles2_help.c
 endif

--- a/v4l2/Makefile.am
+++ b/v4l2/Makefile.am
@@ -58,6 +58,34 @@ libyami_v4l2_la_SOURCES     = $(libyami_v4l2_source_c)
 libyami_v4l2_la_LDFLAGS     = $(libyami_v4l2_ldflags)
 libyami_v4l2_la_CPPFLAGS    = $(libyami_v4l2_cppflags)
 
+if ENABLE_UNITTESTS
+noinst_PROGRAMS = unittest
+
+unittest_SOURCES = \
+	$(top_builddir)/common/unittest_main.cpp \
+	$(NULL)
+
+unittest_LDFLAGS = \
+	$(GTEST_LDFLAGS) \
+	$(NULL)
+
+unittest_LDADD = \
+	libyami_v4l2.la \
+	$(GTEST_LIBS) \
+	$(NULL)
+
+unittest_CPPFLAGS = \
+	$(GTEST_CPPFLAGS) \
+	$(NULL)
+
+unittest_CXXFLAGS = \
+	$(GTEST_CXXFLAGS) \
+	$(NULL)
+
+check-local: unittest
+	$(builddir)/unittest
+endif
+
 DISTCLEANFILES = \
 	Makefile.in
 

--- a/v4l2/Makefile.am
+++ b/v4l2/Makefile.am
@@ -1,55 +1,59 @@
 INCLUDES = -I$(top_srcdir) \
-           -I$(top_srcdir)/interface \
-		   $(NULL)
+	-I$(top_srcdir)/interface \
+	$(NULL)
 
 libyami_v4l2_source_c = \
-        v4l2_codecbase.cpp \
-        v4l2_decode.cpp \
-        v4l2_encode.cpp \
-        v4l2_wrapper.cpp \
-        $(NULL)
+	v4l2_codecbase.cpp \
+	v4l2_decode.cpp \
+	v4l2_encode.cpp \
+	v4l2_wrapper.cpp \
+	$(NULL)
+
 if !ENABLE_V4L2_GLX
 libyami_v4l2_source_c += ../egl/egl_util.c ../egl/egl_vaapi_image.cpp
 endif
 
 libyami_v4l2_source_h = \
-		v4l2_wrapper.h \
-        $(NULL)
+	v4l2_wrapper.h \
+	$(NULL)
 
 libyami_v4l2_source_h_priv = \
-        v4l2_codecbase.h \
-        v4l2_encode.h \
-        v4l2_decode.h \
-        $(NULL)
+	v4l2_codecbase.h \
+	v4l2_encode.h \
+	v4l2_decode.h \
+	$(NULL)
 
 libyami_v4l2_la_LIBADD = \
-		$(top_builddir)/decoder/libyami_decoder.la \
-		$(top_builddir)/encoder/libyami_encoder.la \
-		$(NULL)
+	$(top_builddir)/decoder/libyami_decoder.la \
+	$(top_builddir)/encoder/libyami_encoder.la \
+	$(NULL)
 
 libyami_v4l2_ldflags = \
-        $(LIBYAMI_LT_LDFLAGS) \
-        -lpthread             \
-        $(NULL)
+	$(LIBYAMI_LT_LDFLAGS) \
+	-lpthread             \
+	$(NULL)
+
 if !ENABLE_V4L2_GLX
 libyami_v4l2_ldflags += $(LIBEGL_LIBS)
 endif
 
 libyami_v4l2_cppflags = \
-        $(LIBVA_CFLAGS) \
-        $(LIBV4L2_CFLAGS) \
-        $(NULL)
+	$(LIBVA_CFLAGS) \
+	$(LIBV4L2_CFLAGS) \
+	$(NULL)
+
 if ENABLE_DMABUF
 libyami_v4l2_cppflags += $(LIBDRM_CFLAGS)
 endif
+
 if !ENABLE_V4L2_GLX
 libyami_v4l2_cppflags += $(LIBEGL_CFLAGS)
 endif
 
-lib_LTLIBRARIES	               = libyami_v4l2.la
+lib_LTLIBRARIES             = libyami_v4l2.la
 libyami_v4l2includedir      = $(includedir)/libyami_v4l2
 libyami_v4l2include_HEADERS = $(libyami_v4l2_source_h)
-noinst_HEADERS                 = $(libyami_v4l2_source_h_priv)
+noinst_HEADERS              = $(libyami_v4l2_source_h_priv)
 libyami_v4l2_la_SOURCES     = $(libyami_v4l2_source_c)
 libyami_v4l2_la_LDFLAGS     = $(libyami_v4l2_ldflags)
 libyami_v4l2_la_CPPFLAGS    = $(libyami_v4l2_cppflags)

--- a/vaapi/Makefile.am
+++ b/vaapi/Makefile.am
@@ -45,6 +45,34 @@ libyami_vaapi_la_LDFLAGS     = $(libyami_vaapi_ldflags)
 libyami_vaapi_la_CPPFLAGS    = $(libyami_vaapi_cppflags)
 libyami_vaapi_la_LIBADD      = $(top_builddir)/common/libyami_common.la
 
+if ENABLE_UNITTESTS
+noinst_PROGRAMS = unittest
+
+unittest_SOURCES = \
+	$(top_builddir)/common/unittest_main.cpp \
+	$(NULL)
+
+unittest_LDFLAGS = \
+	$(GTEST_LDFLAGS) \
+	$(NULL)
+
+unittest_LDADD = \
+	libyami_vaapi.la \
+	$(GTEST_LIBS) \
+	$(NULL)
+
+unittest_CPPFLAGS = \
+	$(GTEST_CPPFLAGS) \
+	$(NULL)
+
+unittest_CXXFLAGS = \
+	$(GTEST_CXXFLAGS) \
+	$(NULL)
+
+check-local: unittest
+	$(builddir)/unittest
+endif
+
 DISTCLEANFILES = \
 	Makefile.in 
 

--- a/vaapi/Makefile.am
+++ b/vaapi/Makefile.am
@@ -1,39 +1,40 @@
 INCLUDES = -I$(top_srcdir)
 
 libyami_vaapi_source_c = \
-        vaapipicture.cpp \
-        vaapibuffer.cpp \
-        vaapiimage.cpp \
-        vaapisurface.cpp\
-        vaapiutils.cpp \
-        vaapidisplay.cpp \
-        vaapicontext.cpp \
-        vaapiimagepool.cpp \
+	vaapipicture.cpp \
+	vaapibuffer.cpp \
+	vaapiimage.cpp \
+	vaapisurface.cpp\
+	vaapiutils.cpp \
+	vaapidisplay.cpp \
+	vaapicontext.cpp \
+	vaapiimagepool.cpp \
 	$(NULL)
 
 libyami_vaapi_source_h_priv = \
-        vaapipicture.h \
-        vaapibuffer.h \
-        vaapiimage.h \
-        vaapisurface.h \
-        vaapiutils.h \
-        vaapitypes.h \
-        vaapidisplay.h \
-        vaapicontext.h \
-        vaapiimagepool.h \
+	vaapipicture.h \
+	vaapibuffer.h \
+	vaapiimage.h \
+	vaapisurface.h \
+	vaapiutils.h \
+	vaapitypes.h \
+	vaapidisplay.h \
+	vaapicontext.h \
+	vaapiimagepool.h \
 	$(NULL)
 
 libyami_vaapi_ldflags = \
-        $(LIBYAMI_LT_LDFLAGS) \
-        $(LIBVA_LIBS) \
-        $(LIBVA_DRM_LIBS) \
+	$(LIBYAMI_LT_LDFLAGS) \
+	$(LIBVA_LIBS) \
+	$(LIBVA_DRM_LIBS) \
 	$(NULL)
+
 if ENABLE_X11
 libyami_vaapi_ldflags += $(LIBVA_X11_LIBS) $(X11_LIBS)
 endif
 
 libyami_vaapi_cppflags = \
-        $(LIBVA_CFLAGS) \
+	$(LIBVA_CFLAGS) \
 	$(NULL)
 
 lib_LTLIBRARIES              = libyami_vaapi.la

--- a/vpp/Makefile.am
+++ b/vpp/Makefile.am
@@ -49,5 +49,33 @@ libyami_vpp_la_SOURCES      = $(libyami_vpp_source_c)
 libyami_vpp_la_LDFLAGS      = $(libyami_vpp_ldflags)
 libyami_vpp_la_CPPFLAGS     = $(libyami_vpp_cppflags)
 
+if ENABLE_UNITTESTS
+noinst_PROGRAMS = unittest
+
+unittest_SOURCES = \
+	$(top_builddir)/common/unittest_main.cpp \
+	$(NULL)
+
+unittest_LDFLAGS = \
+	$(GTEST_LDFLAGS) \
+	$(NULL)
+
+unittest_LDADD = \
+	libyami_vpp.la \
+	$(GTEST_LIBS) \
+	$(NULL)
+
+unittest_CPPFLAGS = \
+	$(GTEST_CPPFLAGS) \
+	$(NULL)
+
+unittest_CXXFLAGS = \
+	$(GTEST_CXXFLAGS) \
+	$(NULL)
+
+check-local: unittest
+	$(builddir)/unittest
+endif
+
 DISTCLEANFILES = \
 	Makefile.in

--- a/vpp/Makefile.am
+++ b/vpp/Makefile.am
@@ -1,43 +1,45 @@
 INCLUDES = -I$(top_srcdir) \
-           -I$(top_srcdir)/interface \
-           -I$(top_srcdir)/common \
-           -I$(top_srcdir)/vaapi
+	-I$(top_srcdir)/interface \
+	-I$(top_srcdir)/common \
+	-I$(top_srcdir)/vaapi \
+	$(NULL)
 
 libyami_vpp_source_c = \
-        vaapipostprocess_base.cpp \
-        vaapipostprocess_host.cpp \
-        vaapipostprocess_scaler.cpp \
-        vaapivpppicture.cpp \
-        $(NULL)
+	vaapipostprocess_base.cpp \
+	vaapipostprocess_host.cpp \
+	vaapipostprocess_scaler.cpp \
+	vaapivpppicture.cpp \
+	$(NULL)
 
 
 libyami_vpp_source_h = \
-        ../interface/VideoCommonDefs.h                \
-        ../interface/VideoPostProcessHost.h           \
-        ../interface/VideoPostProcessInterface.h      \
-        $(NULL)
+	../interface/VideoCommonDefs.h \
+	../interface/VideoPostProcessHost.h \
+	../interface/VideoPostProcessInterface.h \
+	$(NULL)
 
 libyami_vpp_source_h_priv = \
-        vaapipostprocess_base.h     \
-        vaapipostprocess_scaler.h   \
-        vaapivpppicture.h           \
-        $(NULL)
+	vaapipostprocess_base.h \
+	vaapipostprocess_scaler.h \
+	vaapivpppicture.h \
+	$(NULL)
 
 libyami_vpp_la_LIBADD = \
-        $(top_builddir)/common/libyami_common.la \
-        $(top_builddir)/vaapi/libyami_vaapi.la
+	$(top_builddir)/common/libyami_common.la \
+	$(top_builddir)/vaapi/libyami_vaapi.la \
+	$(NULL)
 
 libyami_vpp_ldflags = \
-        $(LIBYAMI_LT_LDFLAGS) \
-        $(LIBVA_LIBS) \
-        $(LIBVA_DRM_LIBS) \
-        -ldl                 \
-        $(NULL)
+	$(LIBYAMI_LT_LDFLAGS) \
+	$(LIBVA_LIBS) \
+	$(LIBVA_DRM_LIBS) \
+	-ldl \
+	$(NULL)
 
 libyami_vpp_cppflags = \
-        $(LIBVA_CFLAGS) \
-        $(LIBVA_DRM_CFLAGS) \
-        $(NULL)
+	$(LIBVA_CFLAGS) \
+	$(LIBVA_DRM_CFLAGS) \
+	$(NULL)
 
 lib_LTLIBRARIES             = libyami_vpp.la
 libyami_vppincludedir       = $(includedir)/libyami_vpp
@@ -48,4 +50,4 @@ libyami_vpp_la_LDFLAGS      = $(libyami_vpp_ldflags)
 libyami_vpp_la_CPPFLAGS     = $(libyami_vpp_cppflags)
 
 DISTCLEANFILES = \
-    Makefile.in
+	Makefile.in


### PR DESCRIPTION
GTest is a C++ test framework with a rich set of features that allow you to easily write tests for your project (https://code.google.com/p/googletest/).  This set of patches adds gtest as a dependency (currently optional, but required for unit test compilation).  Each libyami library will compile its own `unittest` executable, which can be individually executed directly or all of them through `make check`.  The unit tests do not require any user interaction and provides multiple types of result output formats. Therefore, they can be easily integrated into an automated testing framework.

On Fedora, the `gtest` and `gtest-devel` packages can be installed via 'yum' or 'dnf'.  I have not checked if other distros provide pre-built packages for gtest.  If they don't, then gtest can be compiled and installed from source easily.

The recommendation is that developers create unit tests to test new code they add, as appropriate.  However, this does not mean that everything can be tested with a unit test, so that judgement will need to be made on a case-by-case basis.

I also recommend that the policy be that all unit tests pass before submitting/merging code to libyami (i.e. no unit test regressions allowed).

Once this patchset is merged, we can start filling in the unit tests to cover the current code.  I've already started some of this in the following branches [unittest-common](https://github.com/uartie/libyami/commits/unittest-common), [unittest-decoder](https://github.com/uartie/libyami/commits/unittest-decoder), and [unittest-encoder](https://github.com/uartie/libyami/commits/unittest-encoder)
